### PR TITLE
Wrong index for disk_size_gb

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -142,7 +142,7 @@ resource "vsphere_virtual_machine" "vm" {
     iterator = template_disks
     content {
       label             = length(var.disk_label) > 0 ? var.disk_label[template_disks.key] : "disk${template_disks.key}"
-      size              = var.disk_size_gb != null ? var.disk_size_gb[template_disks.key] : data.vsphere_virtual_machine.template[0].disks[template_disks.key].size
+      size              = var.disk_size_gb != null ? var.disk_size_gb[count.index] : data.vsphere_virtual_machine.template[0].disks[template_disks.key].size
       unit_number       = var.scsi_controller != null ? var.scsi_controller * 15 + template_disks.key : template_disks.key
       thin_provisioned  = data.vsphere_virtual_machine.template[0].disks[template_disks.key].thin_provisioned
       eagerly_scrub     = data.vsphere_virtual_machine.template[0].disks[template_disks.key].eagerly_scrub


### PR DESCRIPTION
Hello,

The index used to create VMs from clone is not correct.
This MR fix this issue.

Thanks.