### PR TITLE
Add new variable vmnamesuffix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,7 @@ locals {
 resource "vsphere_virtual_machine" "vm" {
   count      = var.instances
   depends_on = [var.vm_depends_on]
-  name       = var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + 1)
+  name       = var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}${var.vmnamesuffix}", count.index + 1)
 
   resource_pool_id        = var.vmrp != "" ? data.vsphere_resource_pool.pool[0].id : var.vmrpid
   folder                  = var.vmfolder

--- a/variables.tf
+++ b/variables.tf
@@ -125,6 +125,11 @@ variable "vmnameformat" {
   default     = "%02d"
 }
 
+variable "vmnamesuffix" {
+  description = "suffix added to the name in vsphere only. default is empty."
+  default     = ""
+}
+
 variable "staticvmname" {
   description = "Static name of the virtual machin. When this option is used VM can not scale out using instance variable. You can use for_each outside the module to deploy multiple static vms with different names"
   default     = null


### PR DESCRIPTION
Hello,

The goal of this PR is to add a new variable to be able to add suffix on the vmname.
Currently it's possible to do this with the vmnameformat variable.
However it's not possible to add full FQDN for example because this name will be used also in the customization part.
This variable only add the capability to use FQDN on the vsphere but not in the customization part.

Thanks.